### PR TITLE
fix: 💫 update title slugify to replace $ symbol

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -251,7 +251,7 @@ fn slugify_title(title: &str) -> String {
             let mut result = String::with_capacity(deunicoded_title.len());
             let mut last_was_replaced = true;
             let remove_characters = "?'`:[]()";
-            let replace_characters = " -/.,"; // include '-' here to avoid "--" in result
+            let replace_characters = " -/.,$"; // include '-' here to avoid "--" in result
             for chars in deunicoded_title.chars() {
                 if replace_characters.contains(chars) {
                     if !last_was_replaced {
@@ -630,7 +630,6 @@ fn form_fenced_code_block_first_line(line: &str) -> IResult<&str, (String, LineT
         ),
     ) = parse_fenced_code_block_first_line(line)?;
 
-    //let mut markup = String::from("<CodeFragment\n  client:visible\n  set:html");
     let mut markup = String::from("<CodeFragment\n  client:visible");
     if let Some(value) = language_option {
         markup.push_str("\n  language=\"");

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -966,4 +966,7 @@ pub fn test_slugify_title() {
         slugify_title(title),
         String::from("surfer-skin-tone-4-all-about-surf")
     );
+
+    let title = "What is $lib?";
+    assert_eq!(slugify_title(title), String::from("what-is-lib"));
 }


### PR DESCRIPTION
# Description

Update the title slugify function which is used to generate HTML IDs based on the title text.  Previously a $ symbol within the title appeaed in the ID.  This change removes the symbol from IDs.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for your
test configuration

- [ ] added new caergo test
- [ ] cargo test run with all tests passing

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
