### PR TITLE
fix: 💫 replace atty with is-terminal to mitigate risk from vulnerability RUSTSEC-2021-0145

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,17 +85,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,9 +205,9 @@ dependencies = [
 name = "cmessless"
 version = "0.1.0"
 dependencies = [
- "atty",
  "clap",
  "deunicode",
+ "is-terminal",
  "miette",
  "nom 7.1.3",
  "tokio",
@@ -457,15 +446,6 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
@@ -511,7 +491,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi",
  "rustix",
  "windows-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ description = "A markdown parser to output Astro markup."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atty = "0.2"
 clap = { version = "4.3", features = ["derive"] }
 deunicode = "1.3.3"
+is-terminal = "0.4.9"
 miette = "5.10"
 nom = { version = "7.1.3", features = ["alloc"] }
 tokio = "1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 mod parser;
 mod utility;
 
-use atty::{is, Stream};
 use clap::Parser;
+use is_terminal::IsTerminal;
 use std::{
     fs,
     io::{self, BufRead},
@@ -210,7 +210,7 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
-    let inputs = if is(Stream::Stdin) {
+    let inputs = if io::stdin().is_terminal() {
         cli.path.to_vec()
     } else {
         get_piped_input()


### PR DESCRIPTION
# Description

Crate atty is currently being used to check for piped stdin. The crate does not appear to be maintained any longer.  OSV lists a vulnerability related to atty (https://osv.dev/vulnerability/RUSTSEC-2021-0145). To mitigate this potential risk, is-terminal is being used to perform the checks, which atty previously preformed.  is-terminal was last updated about 1 month ago and crates.io stats suggest it is commonly used.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] cargo test run with all test passing
- [ ] manual tests run with stdin piped input

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
