### PR TITLE
fix: 💫 replace is-terminal with Rust features introduced in 1.70, add min Rust version to match

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,7 +207,6 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "deunicode",
- "is-terminal",
  "miette",
  "nom 7.1.3",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,12 @@ homepage = "https://rodneylab.com"
 license = "BSD-3-Clause"
 repository = "https://github.com/rodneylab/cmessless"
 description = "A markdown parser to output Astro markup."
+rust-version = "1.70"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 clap = { version = "4.3", features = ["derive"] }
 deunicode = "1.3.3"
-is-terminal = "0.4.9"
 miette = "5.10"
 nom = { version = "7.1.3", features = ["alloc"] }
 tokio = "1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,10 +2,9 @@ mod parser;
 mod utility;
 
 use clap::Parser;
-use is_terminal::IsTerminal;
 use std::{
     fs,
-    io::{self, BufRead},
+    io::{self, BufRead, IsTerminal},
     path::{Path, PathBuf},
 };
 use watchexec::{


### PR DESCRIPTION
# Description

Replace is-terminal crate with Rust features introduced in 1.70. Add a minimum Rust version to match.

- [X] Dependency update

# How Has This Been Tested?

- [ ] cargo test run with all tests passing

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
